### PR TITLE
Fix tail collision detection when snake is not growing

### DIFF
--- a/snake.py
+++ b/snake.py
@@ -108,18 +108,20 @@ def spiel_loop(stdscr: "curses._CursesWindow") -> None:
             kopf_y += 1
 
         neuer_kopf = (kopf_y, kopf_x)
+        wird_wachsen = neuer_kopf == futter
 
         # Kollisionen prüfen
+        koerper_ohne_schwanz = schlange if wird_wachsen else schlange[:-1]
         if (
             kopf_y in (0, max_y - 1)
             or kopf_x in (0, max_x - 1)
-            or neuer_kopf in schlange
+            or neuer_kopf in koerper_ohne_schwanz
         ):
             break
 
         schlange.insert(0, neuer_kopf)
 
-        if neuer_kopf == futter:
+        if wird_wachsen:
             punkte += 1
             futter = platzieren_futter(max_y, max_x, schlange)
         else:


### PR DESCRIPTION
## Summary
- compute whether the snake will grow before running collision checks
- ignore the trailing segment when the snake will move forward so moving into the old tail no longer ends the game
- reuse the growth flag for scoring and food placement decisions

## Testing
- python - <<'PY'

```
schlange = [(5, 5), (5, 4), (5, 3)]
kopf_y, kopf_x = 5, 3
neuer_kopf = (kopf_y, kopf_x)
futter = (1, 1)
wird_wachsen = neuer_kopf == futter
koerper_ohne_schwanz = schlange if wird_wachsen else schlange[:-1]
print("Collision?", neuer_kopf in koerper_ohne_schwanz)
```
PY
- python - <<'PY'

```
schlange = [(5, 5), (5, 4), (5, 3)]
kopf_y, kopf_x = 5, 4
neuer_kopf = (kopf_y, kopf_x)
futter = (1, 1)
wird_wachsen = neuer_kopf == futter
koerper_ohne_schwanz = schlange if wird_wachsen else schlange[:-1]
print("Collision with body?", neuer_kopf in koerper_ohne_schwanz)
```
PY
- python - <<'PY'

```
schlange = [(5, 5), (5, 4), (5, 3)]
kopf_y, kopf_x = 5, 3
neuer_kopf = (kopf_y, kopf_x)
futter = (5, 3)
wird_wachsen = neuer_kopf == futter
koerper_ohne_schwanz = schlange if wird_wachsen else schlange[:-1]
print("Collision while growing?", neuer_kopf in koerper_ohne_schwanz)
```
PY

------
https://chatgpt.com/codex/tasks/task_e_68cc0b2311f88325b79739e21fb2d4a8